### PR TITLE
Change Phoenix availability from Limited to Standard

### DIFF
--- a/data/wallets/phoenix.json
+++ b/data/wallets/phoenix.json
@@ -13,7 +13,7 @@
     "openSource": "yes",
     "availability": {
       "value": "custom",
-      "customText": "Limited (no USA)"
+      "customText": "Standard"
     },
     "custodialStatus": {
       "value": "custom",
@@ -116,6 +116,6 @@
     "noKyc": "yes",
     "transactionLimits": "no"
   },
-  "availability": "Limited (no USA)",
+  "availability": "Standard",
   "category": "L2 Wallet (LN Node)"
 }


### PR DESCRIPTION
Phoenix is no longer absent from US app stores.

Sources:
- https://x.com/PhoenixWallet/status/1909652018207109567 (X-free link: https://xcancel.com/PhoenixWallet/status/1909652018207109567)
- own testing with a VPN.